### PR TITLE
Adjust logic to support longer commands (such as lcd commands)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+micro-evtd.mak

--- a/README
+++ b/README
@@ -16,3 +16,5 @@ micro-evtd -s 0003
 Set a message on the LCD screen:
 micro-evtd -s 20905465726173746174696f6e2061726d2044656269616e20496e7374616c6c657231
 
+I've tested it on armel/armhf and amd64 based Terastations 
+

--- a/README
+++ b/README
@@ -8,13 +8,11 @@ https://buffalonas.miraheze.org/wiki/Terastation_Microcontroller_Interface
 There is also a Python3 library for operating this interface:
 https://github.com/1000001101000/Python_buffalo_libmicon
 
+Usage Examples:
 
-Forum thread:
-http://forum.buffalo.nas-central.org/viewtopic.php?f=7&t=4490
+Send the "boot_end" signal which tells the mcu that the device booted successfully (and not to restart)
+micro-evtd -s 0003
 
-Sourceforge Project:
-https://sourceforge.net/projects/ppc-evtd/
+Set a message on the LCD screen:
+micro-evtd -s 20905465726173746174696f6e2061726d2044656269616e20496e7374616c6c657231
 
-Subversion repository:
-Browse: http://ppc-evtd.svn.sourceforge.net/viewvc/ppc-evtd/micro-evtd/trunk/
-Checkout/Export: https://ppc-evtd.svn.sourceforge.net/svnroot/ppc-evtd/micro-evtd/trunk/

--- a/README
+++ b/README
@@ -1,3 +1,14 @@
+Fork of the original tool for interfacing with the on-board microcontroller on the early linkstations. The original is still included as part of the installation for the LS-GL Debian Installer.
+
+This version includes a few tweaks/fixes to allow the longer commands used to contol LCD displays to function properly. 
+
+Information about the messages that can be used can be found here:
+https://buffalonas.miraheze.org/wiki/Terastation_Microcontroller_Interface
+
+There is also a Python3 library for operating this interface:
+https://github.com/1000001101000/Python_buffalo_libmicon
+
+
 Forum thread:
 http://forum.buffalo.nas-central.org/viewtopic.php?f=7&t=4490
 

--- a/src/micro-evtd.c
+++ b/src/micro-evtd.c
@@ -417,8 +417,8 @@ static int writeUART(int n, unsigned char* output)
 	/* Handle ALL UART messages from a central point, reduce code
 	 * overhead */
 	unsigned char icksum = 0;
-	unsigned char rbuf[32];
-	unsigned char tbuf[32];
+	unsigned char rbuf[35];
+	unsigned char tbuf[35];
 	char retries = 2;
 	int i;
 	fd_set fReadFS;
@@ -455,6 +455,7 @@ static int writeUART(int n, unsigned char* output)
 		FD_ZERO(&fReadFS);
 		FD_SET(i_FileDescriptor, &fReadFS);
 
+		usleep(100000);
 		/* Wait for a max of 500ms for write response */
 		iResult = select(i_FileDescriptor + 1, &fReadFS, NULL, NULL, &tt_TimeoutPoll);
 		/* We did not time-out or error? No, then get data*/

--- a/src/micro-evtd.c
+++ b/src/micro-evtd.c
@@ -1649,11 +1649,9 @@ int main(int argc, char *argv[])
 {
 	int iLen;
 	int i;
-	unsigned long ulMessage;
 	char *thisarg;
 	char iNotQuiet=1;
-	unsigned char* uiDemand = (unsigned char*)&ulMessage;
-	unsigned char uiMessage[10] = {0,};
+	unsigned char uiMessage[36] = {0,};
 	char* pos = NULL;
 	int iSetPriority = -4;
 
@@ -1731,11 +1729,9 @@ int main(int argc, char *argv[])
 			while (pos != 0) {
 				// Get command length
 				iLen = strlen(pos)/2;
-				// Get the HEX command
-				ulMessage = strtoul(pos, NULL, 16);
-				// Byte rotate please
+				// convert each set of two hex chars to corresponding byte
 				for (i=0;i<iLen;i++)
-					uiMessage[i] = uiDemand[iLen-i-1];
+					sscanf(pos+2*i, "%2hhx", &uiMessage[i]);
 				// Push it out and return result
 				i = writeUART(iLen, uiMessage);
 				if (iNotQuiet)

--- a/src/micro-evtd.c
+++ b/src/micro-evtd.c
@@ -489,8 +489,16 @@ again:
 			if (0 == n) {
 				iReturn = (int)rbuf[2];
 				if (len-3 > 1) {
-					for (i=0;i<len-4;i++)
-						printf("%d ", rbuf[2+i]);
+					if ((rbuf[1] & 0x90) ||(rbuf[1] & 0xa0) || ((rbuf[1] >= 0x80) && (rbuf[1] <= 0x83)))
+					{
+						rbuf[len-1]=0;
+						printf("%s\n",rbuf + 2);
+					}
+					else
+					{
+						for (i=0;i<len-4;i++)
+							printf("%d ", rbuf[2+i]);
+					}
 					iReturn = (int)rbuf[2+len-4];
 				}
 

--- a/src/micro-evtd.c
+++ b/src/micro-evtd.c
@@ -1672,7 +1672,7 @@ int main(int argc, char *argv[])
 
 	// Generate unique key.  This will fail with stock so let it be.
 	if ((mutex = ftok(micro_conf, 'M')) == (key_t) -1) {
-	    printf("IPCS: Error, falling back to 'flock'\n");
+	    //printf("IPCS: Error, falling back to 'flock'\n");
 		mutex = 0;
 	}
 


### PR DESCRIPTION
Adjust logic to support longer commands (such as lcd commands). 
This is specifically for adding support for the Orion/Kirkwood/MV78100 Terastations.